### PR TITLE
add scripts/parse_package_version.py in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,3 +35,4 @@ include docs/Makefile
 include docs/spelling_wordlist.txt
 
 include scripts/install_anaconda.sh
+include scripts/parse_package_version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Konstantinos Lampridis'
 author = 'Konstantinos Lampridis'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = '0.3.9'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Now setup.py uses the parse_package_version script, so it should be included in the source distribution.