### PR TITLE
Continuous Integration & Continuous Deployment on CircleCI server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,179 @@
+version: 2.1
+
+executors:
+  py37-docker-image:
+    docker:
+      - image: circleci/python:3.7.9
+  java15-docker-image:
+    docker:
+      - image: cimg/openjdk:15.0.1
+  ubuntu-1604-vm:
+    machine:
+      image: ubuntu-1604:201903-01
+
+jobs:
+  build_n_test:
+    executor: py37-docker-image
+    steps:
+      - run: pwd
+      - checkout
+      - run: python --version
+      - run:
+          name: Equip machine with latest pip & wheel
+          command: python -m pip install -U pip wheel
+      - run:
+          name: Equip machine with tox automation tool
+          command: python -m pip install --user tox
+      - run:
+          name: Equip machine with anaconda (conda executable)
+          command: |
+            chmod +x scripts/install_anaconda.sh
+            scripts/install_anaconda.sh
+      - run:
+          name: Run unittests & measure code coverage
+          command: |
+            export CONDA_EXE=/home/circleci/miniconda/bin/conda
+            python -m tox -e clean,check,py37-cov
+      - store_test_results:  # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: test-results
+      - store_artifacts:
+          path: test-results
+      # currently the 'test-results' path (define above) must match the TEST_RESULTS_DIR env variable found in circleci web site
+      - store_artifacts:
+          path: .coverage
+      - run:
+          name: Transform test results data into xml
+          command: python -m tox -c tox-dev.ini -e report -- coverage xml
+      - run:
+          name: Transform test results-data into html-formatted reports
+          command: python -m tox -c tox-dev.ini -e report -- coverage html
+      - store_artifacts:
+          path: coverage.xml
+      - store_artifacts:
+          path: htmlcov
+          destination: htmlcov
+      # Persist the specified paths (eg .coverage and tox.ini) into the workspace for use in proceeding job.
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
+          # taken to be the root directory of the workspace.
+          root: .
+          # Must be relative path from root
+          paths:
+            - coverage.xml
+            - .coverage
+            - tox.ini
+  
+  send-coverage-to-codacy:
+    executor: java15-docker-image
+    steps:
+      - attach_workspace:
+          at: .
+      - run: curl --version
+      - run: java --version
+      - run:
+          name: Send test data to codacy.com server
+          command: |
+            sudo apt-get install jq
+            curl -LSs "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')" -o codacy-coverage-reporter-assembly.jar
+            java -jar codacy-coverage-reporter-assembly.jar report -l Python -r coverage.xml
+  build-documentation:
+    executor: py37-docker-image
+    steps:
+      - checkout
+      - run:
+          name: Equip machine with tox automation tool
+          command: python -m pip install --user tox
+      - run:
+          name: Install dependencies of documentation building tools
+          command: sudo apt-get install python-enchant
+      - run:
+          name: Install & run documentation building tools
+          command: python -m tox -c tox-dev.ini -e spell,docs
+
+  deploy-to-staging:
+    executor: py37-docker-image
+    environment:
+      CONDA_EXE: /home/circleci/miniconda/bin/conda
+    steps:
+      - checkout
+      - run:
+          name: Install the 'tox' automation tool
+          command: python -m pip install --user tox
+      - run:
+          name: Deploy package (source distro & wheel) to 'testpypi' (index) server
+          command: python -m tox -c tox-dev.ini -e deploy-pypi -vv
+
+  integration-test:
+    executor: py37-docker-image
+    steps:
+      - checkout
+      - run:
+          name: Run the automated integration test script
+          command: |
+            chmod +x scripts/integration-test.sh
+            scripts/integration-test.sh $(python scripts/parse_package_version.py)
+
+#  build_container:
+#    working_directory: ~/build
+#    executor: ubuntu-1604-vm
+#    steps:
+#      - checkout
+#      - run:
+#          name: Build container
+#          command: docker-compose up --build -d
+
+  visualize_dependency_graphs:
+    executor: py37-docker-image
+    steps:
+      - checkout
+      - run: sudo apt-get update -y
+      - run: python -m pip install -U pip
+      - run: sudo apt-get install graphviz
+      - run:
+          name: Install tox automation tool
+          command: python -m pip install --user tox
+      - run: mkdir build-artifacts
+      - run: python -m tox -c tox-dev.ini -e graphs
+      - store_artifacts:
+          path: build-artifacts
+          destination: dep-graphs
+
+workflows:
+  version: 2
+  build_accept:
+    jobs:
+      - build_n_test:
+          filters:
+            tags:
+              only: /.*/  # runs for all branches and all tags
+      - send-coverage-to-codacy:
+          requires:
+            - build_n_test
+          filters:
+            tags:
+              only: /.*/
+      - build-documentation:
+          requires:
+            - build_n_test
+          filters:
+            tags:
+              only: /.*/
+      - visualize_dependency_graphs:
+          requires:
+            - build_n_test
+          filters:
+            branches:
+              only:
+                - master
+      - deploy-to-staging:
+          requires:
+            - build_n_test
+          filters:
+            branches:
+              only: release-staging
+      - integration-test:
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release-staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     name: "Upload the package to the testpypi (index) server"
     python: '3.8'
     script:
-      - tox -e deploy-pypi -vv
+      - tox -c tox-dev.ini -e deploy-pypi -vv
     after_success: skip
   - stage: Integration-test-using-staging
     name: "Emulated a real-world-scenario by installing the package from the testpypi and running the unittests against the installation"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include tests/dts/unittest-dataset-clean.pk
 recursive-include tests *.py
 
 include .travis.yml
+include .circleci/config.yml
 
 include appveyor.yml
 include bandit.yml
@@ -20,6 +21,7 @@ include .appveyor/appveyor-with-compiler.cmd
 
 include .coveragerc
 include tox.ini
+include tox-dev.ini
 
 recursive-include requirements *.txt
 recursive-include src *.py

--- a/scripts/install_anaconda.sh
+++ b/scripts/install_anaconda.sh
@@ -18,13 +18,20 @@ wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-latest-Linu
 
 printf "\n ---- RUNNING mioniconda.sh ----\n"
 
+
+# determine $HOME according to running machine/server
+if [[ "$CIRCLECI" == "true" ]]; then
+  HOME=/home/circleci
+fi
+
 # shellcheck disable=SC2116
 if [[ $(echo "$HOME") ]]; then
-  echo "\$HOME variable is populated, so probably we are running on a 'local' machine";
+  echo "\$HOME variable is populated.";
 else
   HOME=/home/travis
   echo "Assuming we are running on travis CI; setting variable HOME=$HOME"
 fi
+
 
 bash miniconda.sh -b -p "$HOME/miniconda"
 

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -37,7 +37,14 @@ echo '------------ CREATING ENV -------------'
 conda create -p $ENV_PATH -y python=3.7
 
 printf "\n ---- SOURCING ----\n"
-source "$HOME/miniconda/etc/profile.d/conda.sh"
+FILE_TO_SOURCE="$HOME/miniconda/etc/profile.d/conda.sh"
+if [[ ! -f $FILE_TO_SOURCE ]]; then
+  # file does not exist
+  # we try our luck with this simple workaround
+  source "$HOME/miniconda3/etc/profile.d/conda.sh"
+else
+  source "$HOME/miniconda/etc/profile.d/conda.sh"
+fi
 
 printf "\n ---- HASHING ----\n"
 hash -r
@@ -54,7 +61,11 @@ echo '------------ ACTIVATING ENV -------------'
 conda activate $ENV_PATH
 
 echo '------------ INSTALLING DEPS -------------'
-sudo apt-get install --yes gcc gfortran python-dev liblapack-dev cython libblas-dev
+if [[ $(uname -s) == Darwin ]]; then  # we are on macOS
+  echo "We are on macOS: skipping apt-get install command"
+else  # we assume we are on linux
+  sudo apt-get install --yes gcc gfortran python-dev liblapack-dev cython libblas-dev
+fi
 #sudo apt-get install --yes python3-scipy
 echo '------------ INSTALLING PYTHON DEPS -------------'
 python -m pip install -U pip
@@ -72,5 +83,6 @@ python -c 'import so_magic'
 echo "Successfully installed the library emnulating the real 'pip install' scenario using the test-pypi server."
 
 python -m pytest $MY_DIR/../tests -vv --cov
+echo "Successfully installed ran the test suite (unit-tests) that are bundled with the distribution (package) against the 'so-magic' library installed in the system"
 
 echo "SUCCESS!!!"

--- a/tox-dev.ini
+++ b/tox-dev.ini
@@ -1,0 +1,137 @@
+[tox]
+envlist = spell,docs
+skip_missing_interpreters = true
+
+
+[testenv]
+basepython = {clean,report,codecov,graphs,quickstart,spell,docs,deploy-pypi}: {env:TOXPYTHON:python3}
+setenv =
+    PYTHONPATH={toxinidir}/tests
+    PYTHOUNBUFFERED=yes
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+    VIRTUALENV_NO_DOWNLOAD=0
+    BUILD_ARTIFACTS_DIR={toxinidir}/build-artifacts
+    CURRENT_PACKAGE_VERSION=0.3.14
+passenv =
+    *
+    # See https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
+    codecov: TOXENV
+    codecov: CI
+    codecov: TRAVIS TRAVIS_*
+skip_install = true
+
+
+############## DOCS ##############
+[docs-base]
+deps =
+    setuptools >= 40.0.0
+    -rrequirements/docs.txt
+
+[testenv:quickstart]
+description = initialize the sphinx-docs infrastructure, once upon new project creation
+changedir = docs
+use_develop = true
+deps = {[docs-base]deps}
+commands = sphinx-quickstart
+
+[testenv:spell]
+# requires the pyenchant C library (ie on Linux: sudo apt-get install python-pyenchant)
+description = do spell checking on docs; command is allowed to fail
+setenv =
+    SPELLCHECK=1
+deps =
+    {[docs-base]deps}
+    pyenchant
+skip_install = true
+commands = - sphinx-build -b spelling docs dist/docs
+
+[testenv:docs]
+description = build the documentation
+deps = {[docs-base]deps}
+skip_install = true
+commands =
+    sphinx-build {posargs:-E} -b doctest docs dist/docs
+    sphinx-build {posargs:-E} -b html docs dist/docs
+    sphinx-build -b linkcheck docs dist/docs
+
+############## DEPLOY ##############
+
+[deploy-to-pypi-env]
+description = Deploy the python package to be hosted in a pypi server
+basepython = {env:TOXPYTHON:python3}
+deps =
+    keyring==21.3.0
+    twine
+commands_pre = python setup.py sdist bdist_wheel
+
+[testenv:deploy-to-testpypi]
+description = Deploy the python package to be hosted in the testpypi server
+basepython = {[deploy-to-pypi-env]basepython}
+deps = {[deploy-to-pypi-env]deps}
+commands_pre = {[deploy-to-pypi-env]commands_pre}
+commands =
+    python -m twine upload --non-interactive --skip-existing --repository testpypi dist/so[\-_]magic-{env:CURRENT_PACKAGE_VERSION}* --verbose
+
+[testenv:deploy-to-pypi]
+description = Deploy the python package to be hosted in the pypi server
+basepython = {[deploy-to-pypi-env]basepython}
+deps = {[deploy-to-pypi-env]deps}
+commands_pre = {[deploy-to-pypi-env]commands_pre}
+commands =
+    python -m twine upload --non-interactive --repository pypi dist/so[\-_]magic-{env:CURRENT_PACKAGE_VERSION}* --verbose
+
+
+[testenv:deploy-final]
+description = Deploy the python package to be hosted in a pypi server
+basepython = {env:TOXPYTHON:python3}
+deps =
+    keyring==21.3.0
+    twine
+commands_pre =
+    python setup.py sdist bdist_wheel
+    python -m twine upload --non-interactive --repository {env:PYPI_SERVER:testpypi --skip-existing} dist/so[\-_]magic-{env:CURRENT_PACKAGE_VERSION}* --verbose
+
+###### COVERAGE ######
+[testenv:clean]
+deps = coverage
+skip_install = True
+commands = coverage erase
+
+[testenv:report]
+deps = coverage
+skip_install = True
+commands = {posargs:coverage report}
+
+[testenv:format-report]
+deps = coverage
+skip_install = True
+commands =
+    coverage xml
+    coverage html
+
+
+###### CODECOV ######
+[testenv:codecov]
+description = Send code coverage data to codecov.io
+passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+deps = codecov
+skip_install = True
+commands = codecov
+
+
+###### PYDEPS ######
+[testenv:graphs]
+deps = pydeps
+skip_install = True
+passenv = HOME
+commands =
+    pydeps src/so_magic --max-bacon=2 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_1.svg
+    pydeps src/so_magic --max-bacon=4 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_2.svg
+    pydeps src/so_magic --max-bacon=6 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_3.svg
+    pydeps src/so_magic --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_4.svg
+    pydeps src/so_magic --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_5.svg
+
+    pydeps src/so_magic/clustering --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.clustering.svg
+    pydeps src/so_magic/data --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.data.svg
+    pydeps src/so_magic/som --cluster --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.som.svg
+    pydeps src/so_magic/utils --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.utils.svg

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = clean,check,py36-cov,py37-cov,py38-cov,report,spell,docs
+envlist = clean,check,py36-cov,py37-cov,py38-cov
 skip_missing_interpreters = true
 requires = tox-conda
 
 [testenv]
-basepython = {clean,check,report,codecov,graphs,quickstart,spell,docs,deploy-pypi,integration-test}: {env:TOXPYTHON:python3}
+basepython = {clean,check}: {env:TOXPYTHON:python3}
 deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
@@ -23,11 +23,8 @@ passenv =
     codecov: TOXENV
     codecov: CI
     codecov: TRAVIS TRAVIS_*
-commands = {posargs:pytest --cov --cov-report=term-missing -vv --junitxml={env:TEST_RESULTS_DIR:test-results}/{env:JUNIT_TEST_RESULTS:junit-test-results.xml}}
+commands = {posargs:pytest -k test_data_manager --cov --cov-report=term-missing -vv --junitxml={env:TEST_RESULTS_DIR:test-results}/{env:JUNIT_TEST_RESULTS:junit-test-results.xml}}
 
-
-[support]
-skip_install = True
 
 [base]
 commands_pre = python -c 'import nltk; nltk.download("stopwords"); nltk.download("punkt"); nltk.download("wordnet")'
@@ -96,83 +93,7 @@ deps =
     twine
 skip_install = True
 commands =
-    # python setup.py check --metadata --restructuredtext
     check-manifest
     python setup.py sdist bdist_wheel
     twine check dist/so-magic-*.tar.gz
     twine check dist/so_magic-*.whl
-
-
-[testenv:report]
-deps = coverage
-skip_install = True
-commands = {posargs:coverage report -i}
-
-[testenv:codecov]
-description = Send code coverage data to codecov.io
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
-deps = codecov
-skip_install = True
-commands = codecov
-
-
-[testenv:graphs]
-deps = pydeps
-skip_install = True
-passenv = HOME
-commands_pre = python ./scripts/create-dir.py {env:BUILD_ARTIFACTS_DIR}
-commands =
-    pydeps src/so_magic --max-bacon=2 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_1.svg
-    pydeps src/so_magic --max-bacon=4 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_2.svg
-    pydeps src/so_magic --max-bacon=6 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_3.svg
-    pydeps src/so_magic --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_4.svg
-    pydeps src/so_magic --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic_5.svg
-
-    pydeps src/so_magic/clustering --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.clustering.svg
-    pydeps src/so_magic/interfaces --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.interfaces.svg
-    pydeps src/so_magic/som --cluster --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.som.svg
-    pydeps src/so_magic/strain --cluster --max-bacon=8 --noshow -o {env:BUILD_ARTIFACTS_DIR}/so_magic.strain.svg
-
-
-############## DOCS ##############
-[docs-base]
-deps =
-    setuptools >= 40.0.0
-    -rrequirements/docs.txt
-
-[testenv:quickstart]
-changedir = docs
-use_develop = true
-deps = {[docs-base]deps}
-commands = sphinx-quickstart
-
-[testenv:spell]
-# requires the pyenchant C library (ie on Linux: sudo apt-get install python-pyenchant)
-description = an environment to execute the spelling check before building the documentation
-setenv =
-    SPELLCHECK=1
-deps =
-    {[docs-base]deps}
-    pyenchant
-skip_install = true
-commands = - sphinx-build -b spelling docs dist/docs
-
-[testenv:docs]
-description = an environment to build the documentation
-deps = {[docs-base]deps}
-skip_install = true
-commands =
-    sphinx-build {posargs:-E} -b doctest docs dist/docs
-    sphinx-build {posargs:-E} -b html docs dist/docs
-    sphinx-build -b linkcheck docs dist/docs
-
-############## DEPLOY ##############
-[testenv:deploy-pypi]
-description = Deploy the python package to be hosted in a pypi server
-deps =
-    keyring==21.3.0
-    twine
-skip_install = true
-commands =
-    python setup.py sdist bdist_wheel
-    python -m twine upload --non-interactive --skip-existing --repository testpypi dist/so[\-_]magic-{env:CURRENT_PACKAGE_VERSION}* --verbose


### PR DESCRIPTION
update MANIFEST to include the CircleCI server configuration

report on code-coverage and invoke java code to send data to coverage-server

use the py37-docker image as executor of the deps-visual ci job

run tox report command without the -i flag to allow failing if data cannot be parsed

use separate commands for xml and html generation out of .coverage file

separate conda-dependent tox environments

test(integration-test): make code more cross-os (macOS/Linux) & cross-machine compatible (local/ci)

chore(deploy-script): deploy to pypi or testpypi based on staging or production user selection

run dep-graphs job only on master; run deploy-to-staging,integration-test only on release-staging